### PR TITLE
Add StatusBadge component and variant prop to DataCard

### DIFF
--- a/src/stories/DataCard.tsx
+++ b/src/stories/DataCard.tsx
@@ -21,6 +21,8 @@ export interface DataCardProps {
   showActions?: boolean;
   /** Metadata items to display */
   metadata?: { label: string; value: string }[];
+  /** Card visual variant */
+  variant?: 'outlined' | 'filled' | 'elevated';
 }
 
 const statusColors = {
@@ -48,6 +50,7 @@ export const DataCard: React.FC<DataCardProps> = ({
   size = 'medium',
   showActions = true,
   metadata = [],
+  variant = 'outlined',
 }) => {
   const [isHovered, setIsHovered] = useState(false);
 
@@ -60,6 +63,26 @@ export const DataCard: React.FC<DataCardProps> = ({
   const currentSize = sizeStyles[size];
   const statusColor = statusColors[status];
 
+  const variantStyles = {
+    outlined: {
+      border: isSelected ? '2px solid #007bff' : '1px solid #dee2e6',
+      backgroundColor: isHovered ? '#f8f9fa' : '#ffffff',
+      boxShadow: 'none',
+    },
+    filled: {
+      border: isSelected ? '2px solid #007bff' : '1px solid transparent',
+      backgroundColor: isHovered ? '#e9ecef' : '#f8f9fa',
+      boxShadow: 'none',
+    },
+    elevated: {
+      border: isSelected ? '2px solid #007bff' : '1px solid transparent',
+      backgroundColor: isHovered ? '#f8f9fa' : '#ffffff',
+      boxShadow: isHovered ? '0 8px 24px rgba(0,0,0,0.15)' : '0 4px 12px rgba(0,0,0,0.1)',
+    },
+  };
+
+  const currentVariant = variantStyles[variant];
+
   return (
     <div
       onClick={onClick}
@@ -68,9 +91,9 @@ export const DataCard: React.FC<DataCardProps> = ({
       style={{
         padding: currentSize.padding,
         borderRadius: '12px',
-        border: isSelected ? '2px solid #007bff' : '1px solid #dee2e6',
-        backgroundColor: isHovered ? '#f8f9fa' : '#ffffff',
-        boxShadow: isHovered ? '0 4px 12px rgba(0,0,0,0.1)' : '0 2px 4px rgba(0,0,0,0.05)',
+        border: currentVariant.border,
+        backgroundColor: currentVariant.backgroundColor,
+        boxShadow: currentVariant.boxShadow,
         cursor: onClick ? 'pointer' : 'default',
         transition: 'all 0.2s ease',
         maxWidth: '360px',

--- a/src/stories/StatusBadge.tsx
+++ b/src/stories/StatusBadge.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+export interface StatusBadgeProps {
+  /** Display label */
+  label: string;
+  /** Badge status type */
+  type: 'success' | 'warning' | 'error' | 'info' | 'neutral';
+  /** Size variant */
+  size?: 'small' | 'medium' | 'large';
+  /** Show pulsing dot indicator */
+  pulse?: boolean;
+  /** Make the badge rounded pill shape */
+  pill?: boolean;
+  /** Optional icon character to display before label */
+  icon?: string;
+  /** Click handler */
+  onClick?: () => void;
+}
+
+const typeStyles = {
+  success: { bg: '#d4edda', color: '#155724', dot: '#28a745' },
+  warning: { bg: '#fff3cd', color: '#856404', dot: '#ffc107' },
+  error: { bg: '#f8d7da', color: '#721c24', dot: '#dc3545' },
+  info: { bg: '#d1ecf1', color: '#0c5460', dot: '#17a2b8' },
+  neutral: { bg: '#e2e3e5', color: '#383d41', dot: '#6c757d' },
+};
+
+const sizeConfig = {
+  small: { fontSize: '11px', padding: '2px 8px', dotSize: '6px' },
+  medium: { fontSize: '13px', padding: '4px 12px', dotSize: '8px' },
+  large: { fontSize: '15px', padding: '6px 16px', dotSize: '10px' },
+};
+
+export const StatusBadge: React.FC<StatusBadgeProps> = ({
+  label,
+  type,
+  size = 'medium',
+  pulse = false,
+  pill = true,
+  icon,
+  onClick,
+}) => {
+  const style = typeStyles[type];
+  const sizeStyle = sizeConfig[size];
+
+  return (
+    <span
+      onClick={onClick}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: sizeStyle.padding,
+        borderRadius: pill ? '999px' : '6px',
+        backgroundColor: style.bg,
+        color: style.color,
+        fontSize: sizeStyle.fontSize,
+        fontWeight: 500,
+        cursor: onClick ? 'pointer' : 'default',
+        transition: 'opacity 0.2s ease',
+        lineHeight: 1.4,
+      }}
+    >
+      <span
+        style={{
+          width: sizeStyle.dotSize,
+          height: sizeStyle.dotSize,
+          borderRadius: '50%',
+          backgroundColor: style.dot,
+          animation: pulse ? 'statusPulse 1.5s ease-in-out infinite' : 'none',
+          flexShrink: 0,
+        }}
+      />
+      {icon && <span>{icon}</span>}
+      {label}
+      {pulse && (
+        <style>{`
+          @keyframes statusPulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.4; }
+          }
+        `}</style>
+      )}
+    </span>
+  );
+};
+
+export default StatusBadge;


### PR DESCRIPTION
## Summary
- Add new `StatusBadge` component with `type`, `size`, `pulse`, `pill`, `icon` props
- Add `variant` prop (`outlined` / `filled` / `elevated`) to `DataCard` component for visual style control

## Test plan
- [ ] Storybook에서 StatusBadge 컴포넌트 렌더링 확인
- [ ] DataCard의 variant prop 별 스타일 변경 확인
- [ ] `/manage-bui-component-story` 슬래시 커맨드로 스토리 생성/업데이트 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)